### PR TITLE
ErtlFunctionalGroupsFinderTest Update

### DIFF
--- a/Basic/Basic usage instructions.txt
+++ b/Basic/Basic usage instructions.txt
@@ -1,8 +1,9 @@
 --------------------------------------------------------------------------------
 Basic usage instructions with your Java IDE of choice and Java 1.8 (or higher)
 --------------------------------------------------------------------------------
-1. Create new or open existing Java project with unit testing (JUnit version 4 
-   or higher)
+1. Create new or open existing Java project with unit testing
+   (JUnit version 4 or higher - for download & install instructions see 
+   https://github.com/junit-team/junit4/wiki/Download-and-Install)
 2. Add "cdk-2.2.jar" library (located in super directory "CDK") to the Java 
    project (if necessary)
 3. Create package "org.openscience.cdk.tools" (if necessary) and import files 

--- a/Basic/ErtlFunctionalGroupsFinderTest.java
+++ b/Basic/ErtlFunctionalGroupsFinderTest.java
@@ -41,8 +41,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.is;
-
 
 /**
  * Test for ErtlFunctionalGroupsFinder.
@@ -228,21 +226,21 @@ public class ErtlFunctionalGroupsFinderTest {
      * @throws Exception	if anything does not work as planned
      */
     private void assertIsomorphism(List<IAtomContainer> expectedFGs, List<IAtomContainer> actualFGs) {
-    	Assert.assertThat("Number of functional groups does not match the expected number of groups",
-				actualFGs.size(), is(expectedFGs.size()));
+    	Assert.assertEquals("Number of functional groups does not match the expected number of groups",
+                expectedFGs.size(), actualFGs.size());
 
 		for(int i = 0; i < expectedFGs.size(); i++) {
     		IAtomContainer cExp = expectedFGs.get(i);
     		IAtomContainer cAct = actualFGs.get(i);
-    		
-    		Assert.assertThat("Groups #" + i + ": different atom count",
-					cAct.getAtomCount(), is(cExp.getAtomCount()));
-    		Assert.assertThat("Groups #" + i + ": different bond count",
-					cAct.getBondCount(), is(cExp.getBondCount()));
+
+    		Assert.assertEquals("Groups #" + i + ": different atom count",
+                    cExp.getAtomCount(), cAct.getAtomCount());
+    		Assert.assertEquals("Groups #" + i + ": different bond count",
+					cExp.getBondCount(),  cAct.getBondCount());
 
 			Pattern pattern = VentoFoggia.findIdentical(cExp);
 
-			Assert.assertThat("Groups #" + i + ": not isomorph", pattern.matches(cAct), is(true));
+			Assert.assertTrue("Groups #" + i + ": not isomorph", pattern.matches(cAct));
     		
     		Mappings mappings = pattern.matchAll(cAct);
 
@@ -250,14 +248,16 @@ public class ErtlFunctionalGroupsFinderTest {
     		for (Map.Entry<IAtom, IAtom> e : atomMap.entrySet()) {
     	         IAtom atomExp  = e.getKey();
     	         IAtom atomAct = e.getValue();
-    	         Assert.assertThat("Groups #" + i + ": Atom aromaticity does not match" + atomAct.getSymbol() + atomAct.isAromatic() + atomExp.getSymbol() + atomExp.isAromatic(), atomAct.isAromatic(), is(atomExp.isAromatic()));
+    	         Assert.assertEquals("Groups #" + i + ": Atom aromaticity does not match" + atomAct.getSymbol() + atomAct.isAromatic() + atomExp.getSymbol() + atomExp.isAromatic(),
+                         atomExp.isAromatic(), atomAct.isAromatic());
     	     }
 
     		Map<IBond, IBond> bondMap = mappings.toBondMap().iterator().next();
     		for (Map.Entry<IBond, IBond> e : bondMap.entrySet()) {
     	         IBond bondExp  = e.getKey();
     	         IBond bondAct = e.getValue();
-    	         Assert.assertThat("Groups #" + i + ": Bond aromaticity does not match", bondAct.isAromatic(), is(bondExp.isAromatic()));
+    	         Assert.assertEquals("Groups #" + i + ": Bond aromaticity does not match",
+                         bondExp.isAromatic(), bondAct.isAromatic());
     	     }
     	}
     }

--- a/Basic/ErtlFunctionalGroupsFinderTest.java
+++ b/Basic/ErtlFunctionalGroupsFinderTest.java
@@ -23,7 +23,6 @@ package org.openscience.cdk.tools;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openscience.cdk.AtomContainer;
-import org.openscience.cdk.CDKTestCase;
 import org.openscience.cdk.DefaultChemObjectBuilder;
 import org.openscience.cdk.PseudoAtom;
 import org.openscience.cdk.aromaticity.Aromaticity;
@@ -50,7 +49,7 @@ import static org.hamcrest.Matchers.is;
  *
  * @author Sebastian Fritsch
  */
-public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
+public class ErtlFunctionalGroupsFinderTest {
 
     public ErtlFunctionalGroupsFinderTest() {
         super();
@@ -196,78 +195,15 @@ public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
     	testFind(moleculeSmiles, expectedFGs);
 	}
 	
-	@Test
-	public void testFindExtraS() throws Exception { 
-		String moleculeSmiles = "SCCSCC=S";
-    	String[] expectedFGs = new String[] {"HS[R]", "[R]S[R]", "[C]=S"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraRNR() throws Exception {
-		String moleculeSmiles = "CCCCN=CCCC";
-    	String[] expectedFGs = new String[] {"[C]=N[R]"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraPyridine() throws Exception {
-		String moleculeSmiles = "c1ccncc1";
-    	String[] expectedFGs = new String[] {"NarR3"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraRRings1() throws Exception {
-		String moleculeSmiles = "C1N=CC=N1"; // avoid ring with X1-R-X2
-    	String[] expectedFGs = new String[] {"[R]N=CC=N[R]"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraRRings2() throws Exception {
-		String moleculeSmiles = "C1CN=CNO1"; // avoid ring with X1-R-R-X2
-    	String[] expectedFGs = new String[] {"[R]ON([R])C=N[R]"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraAromaticConnectedToAliphatic() throws Exception {
-		String moleculeSmiles = "OC(=O)n1cccc1";
-    	String[] expectedFGs = new String[] {"NarR2COOH"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraEpoxide() throws Exception {
-		String moleculeSmiles = "ClCC1CO1"; // Epichlorohydrin
-    	String[] expectedFGs = new String[] {"[R]Cl", "[C]1[C]O1"};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-
-	@Test
-	public void testFindExtraExplicitHs() throws Exception {
-		String moleculeSmiles = "[H]N([H])[H]";
-		String[] expectedFGs = new String[] {"[R]N([R])[R]"};
-		testFind(moleculeSmiles, expectedFGs);
-	}
-	
-	@Test
-	public void testFindExtraSingleH() throws Exception {
-		String moleculeSmiles = "[H]";
-    	String[] expectedFGs = new String[] {};
-    	testFind(moleculeSmiles, expectedFGs);
-	}
-	
 	private void testFind(String moleculeSmiles, String[] fGStrings) throws Exception {
 		testFind(moleculeSmiles, fGStrings, new Aromaticity(ElectronDonation.daylight(), Cycles.all()));
 	}
 	
 	private void testFind(String moleculeSmiles, String[] fGStrings, Aromaticity aromaticity) throws Exception {
-    	// prepare input
+		// prepare input
 		SmilesParser smilesParser = new SmilesParser(DefaultChemObjectBuilder.getInstance());
-        IAtomContainer mol = smilesParser.parseSmiles(moleculeSmiles);
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
+		IAtomContainer mol = smilesParser.parseSmiles(moleculeSmiles);
+		AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
 		aromaticity.apply(mol);
 
 		// find functional groups
@@ -275,15 +211,14 @@ public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
 		List<IAtomContainer> fGs = fgFinder.find(mol);
 
 		// get expected groups
-        List<IAtomContainer>	expectedFGs = new LinkedList<>();
-        for(String fGString : fGStrings) {
-        	expectedFGs.add(buildFunctionalGroup(fGString));
-        }
+		List<IAtomContainer> expectedFGs = new LinkedList<>();
+		for (String fGString : fGStrings) {
+			expectedFGs.add(buildFunctionalGroup(fGString));
+		}
 
-        // compare
-        this.assertIsomorphism(expectedFGs, fGs);
+		// compare
+		this.assertIsomorphism(expectedFGs, fGs);
 	}
-
 
     /**
      * NOTE: actual and expected functional groups must be in the same order!
@@ -312,14 +247,14 @@ public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
     		Mappings mappings = pattern.matchAll(cAct);
 
     		Map<IAtom, IAtom> atomMap = mappings.toAtomMap().iterator().next();
-    		for (Map.Entry<IAtom,IAtom> e : atomMap.entrySet()) {
+    		for (Map.Entry<IAtom, IAtom> e : atomMap.entrySet()) {
     	         IAtom atomExp  = e.getKey();
     	         IAtom atomAct = e.getValue();
     	         Assert.assertThat("Groups #" + i + ": Atom aromaticity does not match" + atomAct.getSymbol() + atomAct.isAromatic() + atomExp.getSymbol() + atomExp.isAromatic(), atomAct.isAromatic(), is(atomExp.isAromatic()));
     	     }
 
     		Map<IBond, IBond> bondMap = mappings.toBondMap().iterator().next();
-    		for (Map.Entry<IBond,IBond> e : bondMap.entrySet()) {
+    		for (Map.Entry<IBond, IBond> e : bondMap.entrySet()) {
     	         IBond bondExp  = e.getKey();
     	         IBond bondAct = e.getValue();
     	         Assert.assertThat("Groups #" + i + ": Bond aromaticity does not match", bondAct.isAromatic(), is(bondExp.isAromatic()));
@@ -328,10 +263,10 @@ public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
     }
     
     private IAtomContainer buildFunctionalGroup(String string) {
-        IAtom 					a1, a2, a3, a4, a5, a6, a7, a8, a9;
-        IBond 					b1, b2, b3, b4, b5, b6, b7, b8, b9;
-        IChemObjectBuilder 		builder = DefaultChemObjectBuilder.getInstance();
-        IAtomContainer 			container;
+        IAtom a1, a2, a3, a4, a5, a6, a7, a8, a9;
+        IBond b1, b2, b3, b4, b5, b6, b7, b8, b9;
+        IChemObjectBuilder builder = DefaultChemObjectBuilder.getInstance();
+        IAtomContainer container;
 
         // custom templates
         switch(string) {
@@ -377,28 +312,6 @@ public class ErtlFunctionalGroupsFinderTest extends CDKTestCase {
             container = new AtomContainer();
             container.setAtoms(new IAtom[] {a1, a2, a3});
             container.setBonds(new IBond[] {b1, b2});
-            return container;
-            
-        case "NarR2COOH":
-        	a1 = builder.newInstance(IPseudoAtom.class, "R");
-        	a2 = builder.newInstance(IPseudoAtom.class, "R");
-            a3 = builder.newInstance(IAtom.class, "N");
-            a3.setIsAromatic(true);
-            a4 = builder.newInstance(IAtom.class, "C");
-            a5 = builder.newInstance(IAtom.class, "O");
-            a6 = builder.newInstance(IAtom.class, "O");
-            a7 = builder.newInstance(IAtom.class, "H");
-            
-            b1 = builder.newInstance(IBond.class, a1, a3, Order.SINGLE);
-            b2 = builder.newInstance(IBond.class, a2, a3, Order.SINGLE);
-            b3 = builder.newInstance(IBond.class, a3, a4, Order.SINGLE);
-            b4 = builder.newInstance(IBond.class, a4, a5, Order.DOUBLE);
-            b5 = builder.newInstance(IBond.class, a4, a6, Order.SINGLE);
-            b6 = builder.newInstance(IBond.class, a6, a7, Order.SINGLE);
-                    
-            container = new AtomContainer();
-            container.setAtoms(new IAtom[] {a1, a2, a3, a4, a5, a6, a7});
-            container.setBonds(new IBond[] {b1, b2, b3, b4, b5, b6});
             return container;
 
             // smiles

--- a/Evaluation/Evaluation usage instructions.txt
+++ b/Evaluation/Evaluation usage instructions.txt
@@ -2,8 +2,9 @@
 Evaluation usage instructions with your Java IDE of choice and Java 1.8 
 (or higher)
 --------------------------------------------------------------------------------
-1. Create new or open existing Java project with unit testing (JUnit version 4 
-   or higher)
+1. Create new or open existing Java project with unit testing
+   (JUnit version 4 or higher - for download & install instructions see 
+   https://github.com/junit-team/junit4/wiki/Download-and-Install)
 2. Add "cdk-2.2.jar" library (located in super directory "CDK") to the Java 
    project (if necessary)
 3. Create package "org.openscience.cdk.tools" (if necessary) and import files 


### PR DESCRIPTION
hier ist ein Update von ErtlFunctionalGroupsFinder Test.
Die Abhängigkeiten zum CDKTestCase wurden entfernt und die "asserts" umgeschrieben um die Einbindung einer zusätzlichen jar (hamcrest-all-1.3.jar) zu vermeiden.

Beim vorherigen Pull-Request ist mir etwas schief gelaufen. Also nicht wundern, den habe ich absichtlich wieder geschlossen und das kannst du ignorieren.

Gruß
Sebastian